### PR TITLE
Add j flag to make to parallelize the build

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -36,7 +36,7 @@ build() {
     --disable-mruby
 
   msg2 "Build ArangoDB project ..."
-  make
+  make -j $(nproc)
 }
 
 check() {


### PR DESCRIPTION
This change feeds the number of processors (as reported by nproc) to make's
-j/--jobs option. Make will then use all the processors on the machine
during the compilation process, which should speed things up
significantly.
